### PR TITLE
feat: Add Simplified Promise API with Callback Support

### DIFF
--- a/docs/promises-api.md
+++ b/docs/promises-api.md
@@ -1,0 +1,250 @@
+# Promises API for Cross-Contract Calls
+
+NEAR's smart contracts can interact with each other through asynchronous cross-contract calls. The NEAR Python SDK provides an enhanced Promises API to make working with these asynchronous workflows easier and more reliable.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Basic Cross-Contract Calls](#basic-cross-contract-calls)
+- [Using Callbacks](#using-callbacks)
+- [The `@callback` Decorator](#the-callback-decorator)
+- [Promise Chaining](#promise-chaining)
+- [Error Handling](#error-handling)
+- [Advanced Usage](#advanced-usage)
+- [Best Practices](#best-practices)
+
+## Overview
+
+In NEAR, when one contract calls another, the call returns a *Promise*. Promises are NEAR's way of handling asynchronous operations between contracts. The NEAR Python SDK provides a clean API for working with these promises through the `CrossContract` class and the `@callback` decorator.
+
+## Basic Cross-Contract Calls
+
+Making a simple cross-contract call:
+
+```python
+from near_sdk_py import call, ONE_TGAS, CrossContract
+
+@call
+def get_token_info(self, token_account_id: str) -> int:
+    """Call another contract and return the promise directly"""
+    promise = CrossContract.call(
+        account_id=token_account_id,      # Contract to call 
+        method_name="ft_metadata",        # Method to call
+        args={},                          # Arguments (empty in this case)
+        amount=0,                         # Attached deposit in yoctoNEAR
+        gas=5 * ONE_TGAS                  # Gas to attach
+    )
+    
+    # The return value of the called contract will be returned to the caller
+    return CrossContract.return_value(promise)
+```
+
+## Using Callbacks
+
+Often, you'll want to process the result of a cross-contract call before returning it to the user. This is where callbacks come in:
+
+```python
+from near_sdk_py import call, callback, ONE_TGAS, CrossContract, Log
+
+class TokenAggregator:
+    @call
+    def get_token_price_in_usd(self, token_account_id: str) -> int:
+        """Get token price and convert it to USD"""
+        
+        # Using the simplified call_with_callback method
+        promise = CrossContract.call_with_callback(
+            account_id=token_account_id,   # Contract to call
+            method_name="get_price",       # Method to call
+            args={},                       # Arguments
+            gas=5 * ONE_TGAS,              # Gas for the call
+            callback_method="on_price_received"  # Our callback method
+        )
+        
+        # This will execute the callback and return its result
+        return CrossContract.return_value(promise)
+    
+    @callback
+    def on_price_received(self, promise_result: dict) -> float:
+        """Process the token price result"""
+        if promise_result["status"] != "Successful":
+            # Handle the error case
+            Log.error(f"Failed to get token price: {promise_result['status']}")
+            return 0.0
+            
+        # Parse the result (assuming it's a JSON string)
+        import json
+        price_data = json.loads(promise_result["data"].decode("utf-8"))
+        
+        # Convert to USD using our exchange rate
+        usd_price = price_data["price"] * 1.25  # Example conversion
+        
+        return usd_price
+```
+
+## The `@callback` Decorator
+
+The `@callback` decorator is specifically designed for handling promise results. When you use this decorator:
+
+1. Your method will automatically receive a `promise_result` parameter with:
+   - `status`: A string representing the promise status ('Successful', 'Failed', or 'NotReady')
+   - `status_code`: The numeric status code (1 for success, 2 for failure, 0 for not ready)
+   - `data`: The raw bytes returned by the promise (if successful)
+
+2. Your return value will be properly serialized to be returned to the caller
+
+Example:
+
+```python
+@callback
+def on_data_received(self, promise_result: dict) -> dict:
+    """Process data from another contract"""
+    if promise_result["status"] != "Successful":
+        return {"error": f"Call failed with status: {promise_result['status']}"}
+        
+    # Process the data
+    data = promise_result["data"].decode("utf-8")
+    parsed_data = json.loads(data)
+    
+    # Transform or enhance the data
+    processed_data = {
+        "original": parsed_data,
+        "processed_at": Context.block_timestamp(),
+        "processor": Context.current_account_id()
+    }
+    
+    return processed_data
+```
+
+## Promise Chaining
+
+You can chain multiple promises together to create more complex workflows:
+
+```python
+@call
+def process_data_pipeline(self, data_source: str, processor: str) -> int:
+    """
+    Create a data processing pipeline across multiple contracts:
+    1. Get data from data_source contract
+    2. Process it with the processor contract
+    3. Handle the final result in our callback
+    """
+    # First promise: get data
+    promise1 = CrossContract.call(
+        data_source, 
+        "get_data",
+        {},
+        0,
+        10 * ONE_TGAS
+    )
+    
+    # Second promise: process data
+    promise2 = CrossContract.then(
+        promise1,
+        processor,
+        "process_data",
+        {},
+        0,
+        10 * ONE_TGAS
+    )
+    
+    # Final callback: handle the processed data
+    final_promise = CrossContract.then(
+        promise2,
+        Context.current_account_id(),
+        "on_processing_complete",
+        {},
+        0,
+        10 * ONE_TGAS
+    )
+    
+    return CrossContract.return_value(final_promise)
+```
+
+## Error Handling
+
+Always check the status of promises in your callbacks:
+
+```python
+@callback
+def on_result(self, promise_result: dict):
+    if promise_result["status"] == "NotReady":
+        return {"error": "Promise not ready yet"}
+    elif promise_result["status"] == "Failed":
+        return {"error": "The cross-contract call failed"}
+    
+    # Process the successful result
+    # ...
+```
+
+## Advanced Usage
+
+### Parallel Promises
+
+You can execute multiple promises in parallel and then combine their results:
+
+```python
+@call
+def aggregate_data(self, source1: str, source2: str) -> int:
+    """Call multiple contracts and aggregate their results"""
+    
+    # Create multiple promises
+    promise1 = CrossContract.call(source1, "get_data", {}, 0, 5 * ONE_TGAS)
+    promise2 = CrossContract.call(source2, "get_data", {}, 0, 5 * ONE_TGAS)
+    
+    # Combine promises and add a callback
+    combined_promise = CrossContract.and_then(
+        [promise1, promise2],
+        Context.current_account_id(),
+        "on_combined_data",
+        {},
+        0,
+        10 * ONE_TGAS
+    )
+    
+    return CrossContract.return_value(combined_promise)
+
+@callback
+def on_combined_data(self, promise_result: dict):
+    # Here you'd need to handle multiple promise results
+    # This is a simplified example
+    # ...
+```
+
+### Manual Promise Management
+
+For more control, you can use the lower-level API:
+
+```python
+@call
+def execute_complex_workflow(self, target: str, data: dict) -> int:
+    # Initial call
+    promise = CrossContract.call(target, "process", data, 0, 15 * ONE_TGAS)
+    
+    # Callback with specific gas allocation
+    callback = CrossContract.then(
+        promise,
+        Context.current_account_id(),
+        "on_process_complete",
+        {"original_data": data},  # Pass additional context to callback
+        0,
+        15 * ONE_TGAS
+    )
+    
+    return CrossContract.return_value(callback)
+```
+
+## Best Practices
+
+1. **Gas Management**: Always allocate enough gas for both the cross-contract call and your callback.
+
+2. **Error Handling**: Always check the promise status in callbacks.
+
+3. **Data Serialization**: Be careful with data formats. Remember that promise results are returned as raw bytes.
+
+4. **Testing**: Test cross-contract calls thoroughly, including error cases.
+
+5. **Callback Structure**: Keep callbacks focused on processing the specific promise result they're designed for.
+
+6. **Documentation**: Document the expected callback behavior for complex promise chains.
+
+7. **Security**: Be cautious about which contracts you call and validate their responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "near-sdk-py"
-version = "0.1.2"
+version = "0.1.3"
 description = "A higher-level API for building NEAR smart contracts in Python."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/near_sdk_py/__init__.py
+++ b/src/near_sdk_py/__init__.py
@@ -10,7 +10,7 @@ from .context import Context
 from .log import Log
 from .value_return import ValueReturn
 from .cross_contract import CrossContract
-from .decorators import export, contract_method, view, call, init
+from .decorators import export, contract_method, view, call, init, callback
 from .constants import ONE_TGAS, MAX_GAS, ONE_NEAR
 
 
@@ -36,6 +36,7 @@ __all__ = [
     "view",
     "call",
     "init",
+    "callback",
     "ONE_NEAR",
     "ONE_TGAS",
     "MAX_GAS",

--- a/src/near_sdk_py/cross_contract.py
+++ b/src/near_sdk_py/cross_contract.py
@@ -3,7 +3,7 @@ Utilities for cross-contract calls in NEAR smart contracts.
 """
 
 import json
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 import near
 
@@ -16,6 +16,24 @@ MAX_GAS = 300 * ONE_TGAS  # 300 TGas
 class CrossContract:
     """
     Utilities for cross-contract calls
+
+    Examples:
+    ---------
+
+    # Simple cross-contract call
+    promise = CrossContract.call("example.near", "get_data")
+
+    # Cross-contract call with automatic callback
+    promise = CrossContract.call_with_callback(
+        "example.near",           # Target contract
+        "get_data",               # Target method
+        callback_method="on_data_received"  # Local callback method
+    )
+
+    # Complex promise chain
+    promise = CrossContract.call("contract1.near", "method1")
+    callback = CrossContract.then(promise, "contract2.near", "method2")
+    CrossContract.return_value(callback)
     """
 
     @staticmethod
@@ -40,6 +58,44 @@ class CrossContract:
         return near.promise_create(account_id, method_name, args_str, amount, gas)
 
     @staticmethod
+    def call_with_callback(
+        account_id: str,
+        method_name: str,
+        args: Any = None,
+        amount: int = 0,
+        gas: int = MAX_GAS // 3,
+        callback_gas: Optional[int] = None,
+        callback_method: Optional[str] = None,
+        callback_args: Any = None,
+    ) -> int:
+        """
+        Makes a cross-contract call with an automatic callback to the current contract
+
+        Returns the final promise index that can be used with return_value()
+        """
+        if callback_method is None:
+            raise ValueError("callback_method is required for call_with_callback")
+
+        # Default callback gas to be one-third of the remaining gas
+        if callback_gas is None:
+            callback_gas = gas // 3
+
+        # Make the initial cross-contract call
+        promise_idx = CrossContract.call(account_id, method_name, args, amount, gas)
+
+        # Chain the callback
+        current_account = near.current_account_id()
+        final_promise = CrossContract.then(
+            promise_idx,
+            current_account,
+            callback_method,
+            callback_args,
+            0,
+            callback_gas,
+        )
+        return final_promise
+
+    @staticmethod
     def then(
         promise_idx: int,
         account_id: str,
@@ -62,6 +118,24 @@ class CrossContract:
         return near.promise_then(
             promise_idx, account_id, method_name, args_str, amount, gas
         )
+
+    @staticmethod
+    def get_result(promise_idx: int = 0) -> Dict[str, Any]:
+        """
+        Gets the result of a promise for callback processing
+
+        Returns a dictionary with:
+            - 'status': 'NotReady', 'Successful', or 'Failed'
+            - 'data': bytes object containing the result data if successful
+        """
+        status_code, data = near.promise_result(promise_idx)
+        status = (
+            ["NotReady", "Successful", "Failed"][status_code]
+            if 0 <= status_code <= 2
+            else "Unknown"
+        )
+
+        return {"status": status, "data": data, "status_code": status_code}
 
     @staticmethod
     def and_then(

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -43,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "near-sdk-py"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This PR adds a more streamlined approach to handling cross-contract calls and promises in NEAR Python SDK:

- Adds `@callback` decorator for handling promise results
- Introduces `CrossContract.call_with_callback()` for simplified promise chains
- Provides structured promise result objects with status information
- Updates README with clear examples
- Adds detailed documentation in `docs/promises-api.md`

## Example usage:

```python
@call
def get_data(self, source_contract: str):
    return CrossContract.call_with_callback(
        source_contract, 
        "fetch_data",
        callback_method="on_data_received"
    )

@callback
def on_data_received(self, promise_result: dict):
    if promise_result["status"] == "Successful":
        return json.loads(promise_result["data"].decode("utf-8"))
    return {"error": "Failed to fetch data"}
```