### PR TITLE
fix(lint): sort imports

### DIFF
--- a/integration_tests/contracts/account_operations_contract.py
+++ b/integration_tests/contracts/account_operations_contract.py
@@ -8,10 +8,10 @@ This contract demonstrates complex Promise patterns with batch operations:
 - Executing complex multi-operation sequences
 """
 
-from near_sdk_py import call, view, Storage, Context, Log
-from near_sdk_py.promises import Promise, callback, PromiseResult
-from near_sdk_py import ONE_TGAS, ONE_NEAR
 from typing import Optional
+
+from near_sdk_py import ONE_NEAR, ONE_TGAS, Context, Log, Storage, call, view
+from near_sdk_py.promises import Promise, PromiseResult, callback
 
 
 class AccountOperationsContract:

--- a/integration_tests/contracts/basic_contract.py
+++ b/integration_tests/contracts/basic_contract.py
@@ -7,7 +7,7 @@ This contract demonstrates the simplest forms of Promise usage:
 - Direct return of promise results
 """
 
-from near_sdk_py import call, view, Storage
+from near_sdk_py import Storage, call, view
 from near_sdk_py.promises import CrossContract
 
 

--- a/integration_tests/contracts/callback_contract.py
+++ b/integration_tests/contracts/callback_contract.py
@@ -7,10 +7,10 @@ This contract demonstrates callback patterns with NEAR Promises:
 - Data passing between promises in a chain
 """
 
-from near_sdk_py import call, view, Storage, Log
-from near_sdk_py.promises import CrossContract, callback, multi_callback, PromiseResult
-from near_sdk_py import ONE_TGAS
 from typing import List
+
+from near_sdk_py import ONE_TGAS, Log, Storage, call, view
+from near_sdk_py.promises import CrossContract, PromiseResult, callback, multi_callback
 
 
 class CallbackContract:

--- a/integration_tests/contracts/callback_security_contract.py
+++ b/integration_tests/contracts/callback_security_contract.py
@@ -7,9 +7,8 @@ This contract includes methods to test:
 3. Callback access from another contract (should fail)
 """
 
-from near_sdk_py import call, view, Storage, Context, Log
-from near_sdk_py.promises import CrossContract, callback, PromiseResult
-from near_sdk_py import ONE_TGAS
+from near_sdk_py import ONE_TGAS, Context, Log, Storage, call, view
+from near_sdk_py.promises import CrossContract, PromiseResult, callback
 
 
 class CallbackSecurityContract:

--- a/integration_tests/contracts/error_handling_contract.py
+++ b/integration_tests/contracts/error_handling_contract.py
@@ -7,9 +7,8 @@ This contract demonstrates error handling patterns with NEAR Promises:
 - Graceful error handling in callbacks
 """
 
-from near_sdk_py import call, view, Storage, Log
-from near_sdk_py.promises import CrossContract, callback, PromiseResult
-from near_sdk_py import ONE_TGAS
+from near_sdk_py import ONE_TGAS, Log, Storage, call, view
+from near_sdk_py.promises import CrossContract, PromiseResult, callback
 
 
 class ErrorHandlingContract:

--- a/integration_tests/contracts/greeting_contract.py
+++ b/integration_tests/contracts/greeting_contract.py
@@ -1,4 +1,4 @@
-from near_sdk_py import Contract, view, call, init
+from near_sdk_py import Contract, call, init, view
 
 
 class GreetingContract(Contract):

--- a/integration_tests/contracts/ownership_contract.py
+++ b/integration_tests/contracts/ownership_contract.py
@@ -1,4 +1,4 @@
-from near_sdk_py import Contract, view, call, init
+from near_sdk_py import Contract, call, init, view
 
 
 class OwnershipContract(Contract):

--- a/integration_tests/contracts/storage_contract.py
+++ b/integration_tests/contracts/storage_contract.py
@@ -1,4 +1,4 @@
-from near_sdk_py import Contract, view, call, init
+from near_sdk_py import Contract, call, init, view
 
 
 class StorageContract(Contract):

--- a/integration_tests/contracts/token_gas_contract.py
+++ b/integration_tests/contracts/token_gas_contract.py
@@ -7,10 +7,10 @@ This contract demonstrates how to:
 - Transfer tokens between accounts
 """
 
-from near_sdk_py import call, view, Storage, Context, Log
-from near_sdk_py.promises import CrossContract, callback, PromiseResult
-from near_sdk_py import ONE_TGAS
 from typing import Optional
+
+from near_sdk_py import ONE_TGAS, Context, Log, Storage, call, view
+from near_sdk_py.promises import CrossContract, PromiseResult, callback
 
 
 class TokenGasContract:

--- a/integration_tests/promises/test_account_operations.py
+++ b/integration_tests/promises/test_account_operations.py
@@ -10,9 +10,10 @@ This module demonstrates complex account operations with NEAR's Promises API:
 These examples show how to perform advanced operations with promises.
 """
 
-from near_pytest.testing import NearTestCase
 import json
 import secrets
+
+from near_pytest.testing import NearTestCase
 
 
 class TestAccountOperations(NearTestCase):

--- a/integration_tests/promises/test_callback_security.py
+++ b/integration_tests/promises/test_callback_security.py
@@ -12,8 +12,9 @@ The tests include:
 - A more complex test with a fake callback context (testing specifically the self-call check)
 """
 
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestCallbackSecurity(NearTestCase):

--- a/integration_tests/promises/test_callbacks.py
+++ b/integration_tests/promises/test_callbacks.py
@@ -10,8 +10,9 @@ This module demonstrates how to use callbacks with NEAR's Promises API:
 These examples show how to process data returned from other contracts.
 """
 
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestPromiseCallbacks(NearTestCase):

--- a/integration_tests/promises/test_error_handling.py
+++ b/integration_tests/promises/test_error_handling.py
@@ -10,8 +10,9 @@ These examples show how to build robust cross-contract interactions
 that can handle failure cases gracefully.
 """
 
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestPromiseErrorHandling(NearTestCase):

--- a/integration_tests/promises/test_token_gas.py
+++ b/integration_tests/promises/test_token_gas.py
@@ -10,8 +10,9 @@ This module demonstrates how to manage tokens and gas with NEAR's Promises API:
 These examples show how to work with NEAR's economic model in promises.
 """
 
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestTokenGasManagement(NearTestCase):

--- a/integration_tests/test_greeting.py
+++ b/integration_tests/test_greeting.py
@@ -1,5 +1,6 @@
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestSimpleGreetingContract(NearTestCase):

--- a/integration_tests/test_ownership.py
+++ b/integration_tests/test_ownership.py
@@ -1,5 +1,6 @@
-from near_pytest.testing import NearTestCase
 import json
+
+from near_pytest.testing import NearTestCase
 
 
 class TestOwnershipContract(NearTestCase):

--- a/integration_tests/test_storage.py
+++ b/integration_tests/test_storage.py
@@ -1,5 +1,6 @@
-from near_pytest import NearTestCase
 import json
+
+from near_pytest import NearTestCase
 
 
 class TestStorageContract(NearTestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ branch = "main"
 changelog_file = "CHANGELOG.md"
 commit_message = "chore(release): {version} [skip ci]"
 build_command = "uv build"
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/src/near/__init__.py
+++ b/src/near/__init__.py
@@ -12,21 +12,18 @@ from typing import Callable
 __all__ = ["export"]  # Will add imported functions to this list
 
 # Import and re-export all functions from submodules
-from .registers import read_register, read_register_as_str, register_len, write_register
-
 from .context import (
-    current_account_id,
-    signer_account_id,
-    signer_account_pk,
-    predecessor_account_id,
-    input,
-    input_as_str,
     block_height,
     block_timestamp,
+    current_account_id,
     epoch_height,
+    input,
+    input_as_str,
+    predecessor_account_id,
+    signer_account_id,
+    signer_account_pk,
     storage_usage,
 )
-
 from .economics import (
     account_balance,
     account_locked_balance,
@@ -34,47 +31,42 @@ from .economics import (
     prepaid_gas,
     used_gas,
 )
-
 from .math import (
-    random_seed,
-    sha256,
-    keccak256,
-    keccak512,
-    ripemd160,
     ecrecover,
     ed25519_verify,
+    keccak256,
+    keccak512,
+    random_seed,
+    ripemd160,
+    sha256,
 )
-
-from .storage import storage_write, storage_read, storage_remove, storage_has_key
-
+from .misc import abort, log, log_utf8, log_utf16, panic, panic_utf8, value_return
 from .promises import (
-    promise_create,
-    promise_then,
     promise_and,
-    promise_batch_create,
-    promise_batch_then,
+    promise_batch_action_add_key_with_full_access,
+    promise_batch_action_add_key_with_function_call,
     promise_batch_action_create_account,
+    promise_batch_action_delete_account,
+    promise_batch_action_delete_key,
     promise_batch_action_deploy_contract,
     promise_batch_action_function_call,
     promise_batch_action_function_call_weight,
-    promise_batch_action_transfer,
     promise_batch_action_stake,
-    promise_batch_action_add_key_with_full_access,
-    promise_batch_action_add_key_with_function_call,
-    promise_batch_action_delete_key,
-    promise_batch_action_delete_account,
-    promise_yield_create,
-    promise_yield_resume,
-    promise_results_count,
+    promise_batch_action_transfer,
+    promise_batch_create,
+    promise_batch_then,
+    promise_create,
     promise_result,
     promise_result_as_str,
+    promise_results_count,
     promise_return,
+    promise_then,
+    promise_yield_create,
+    promise_yield_resume,
 )
-
+from .registers import read_register, read_register_as_str, register_len, write_register
+from .storage import storage_has_key, storage_read, storage_remove, storage_write
 from .validator import validator_stake, validator_total_stake
-
-from .misc import value_return, panic, panic_utf8, log_utf8, log, log_utf16, abort
-
 
 # Update __all__ with all imported functions
 # Register functions

--- a/src/near/storage.py
+++ b/src/near/storage.py
@@ -5,7 +5,7 @@ This module provides functions for interacting with the persistent on-chain stor
 of a NEAR smart contract.
 """
 
-from typing import Optional, Union, Tuple
+from typing import Optional, Tuple, Union
 
 
 def storage_write(key: Union[bytes, str], value: Union[bytes, str]) -> Optional[bytes]:

--- a/src/near_sdk_py/__init__.py
+++ b/src/near_sdk_py/__init__.py
@@ -3,16 +3,15 @@ This module provides higher-level abstractions over the low-level NEAR API,
 making it easier to write smart contracts with Python.
 """
 
+from .constants import MAX_GAS, ONE_NEAR, ONE_TGAS
+from .context import Context
 from .contract import Contract, ContractError, StorageError
+from .decorators import call, contract_method, init, view
+from .input import Input
+from .log import Log
 from .promises import CrossContract, Promise, PromiseResult, callback
 from .storage import Storage
-from .input import Input
-from .context import Context
-from .log import Log
 from .value_return import ValueReturn
-from .decorators import contract_method, view, call, init
-from .constants import ONE_TGAS, MAX_GAS, ONE_NEAR
-
 
 # Type definitions
 AccountId = str

--- a/src/near_sdk_py/collections/__init__.py
+++ b/src/near_sdk_py/collections/__init__.py
@@ -47,15 +47,15 @@ class TokenContract:
 ```
 """
 
-from .base import Collection, PrefixType
 from .adapter import CollectionStorageAdapter
-from .vector import Vector
+from .base import Collection, PrefixType
 from .lookup_map import LookupMap
-from .unordered_map import UnorderedMap, IterableMap
 from .lookup_set import LookupSet
-from .unordered_set import UnorderedSet, IterableSet
 from .tree_map import TreeMap
+from .unordered_map import IterableMap, UnorderedMap
+from .unordered_set import IterableSet, UnorderedSet
 from .utils import create_enum_prefix, create_prefix_guard
+from .vector import Vector
 
 # Export the collection classes
 __all__ = [

--- a/src/near_sdk_py/decorators.py
+++ b/src/near_sdk_py/decorators.py
@@ -2,13 +2,15 @@
 Decorator utilities for NEAR smart contracts.
 """
 
+import json
+from functools import wraps
+
 import near
+
+from .contract import ContractError, ContractPanic
 from .input import Input
 from .log import Log
-import json
 from .value_return import ValueReturn
-from .contract import ContractPanic, ContractError
-from functools import wraps
 
 
 def contract_method(func):

--- a/src/near_sdk_py/input.py
+++ b/src/near_sdk_py/input.py
@@ -4,9 +4,10 @@ Input handling utilities for NEAR smart contracts.
 
 import json
 from typing import Any
-from .contract import InvalidInput
 
 import near
+
+from .contract import InvalidInput
 
 
 class Input:

--- a/src/near_sdk_py/promises/__init__.py
+++ b/src/near_sdk_py/promises/__init__.py
@@ -7,8 +7,8 @@ cross-contract calls with method chaining and modern Python syntax.
 
 from .batch import BatchAction, PromiseBatch
 from .contract import CrossContract
-from .promise import Promise, PromiseResult
 from .decorators import callback, multi_callback
+from .promise import Promise, PromiseResult
 
 __all__ = [
     "BatchAction",

--- a/src/near_sdk_py/promises/contract.py
+++ b/src/near_sdk_py/promises/contract.py
@@ -1,8 +1,10 @@
-import near
 import json
+
+import near
 from near_sdk_py.constants import ONE_TGAS
-from .promise import Promise
+
 from .batch import PromiseBatch
+from .promise import Promise
 
 
 class CrossContract:

--- a/src/near_sdk_py/promises/decorators.py
+++ b/src/near_sdk_py/promises/decorators.py
@@ -5,14 +5,15 @@ This module provides a more intuitive, Pythonic interface for NEAR's
 cross-contract calls with method chaining and modern Python syntax.
 """
 
-from typing import Any, Callable
-from functools import wraps
-
 import json
+from functools import wraps
+from typing import Any, Callable
+
 import near
-from near_sdk_py.value_return import ValueReturn
-from .promise import PromiseResult
 from near_sdk_py.input import Input
+from near_sdk_py.value_return import ValueReturn
+
+from .promise import PromiseResult
 
 STATUS_NOT_READY = 0
 STATUS_SUCCESSFUL = 1

--- a/src/near_sdk_py/promises/promise.py
+++ b/src/near_sdk_py/promises/promise.py
@@ -5,11 +5,12 @@ This module provides a more intuitive, Pythonic interface for NEAR's
 cross-contract calls with method chaining and modern Python syntax.
 """
 
+import json
 from typing import List, TypeVar
 
 import near
-import json
 from near_sdk_py.constants import ONE_TGAS
+
 from .batch import PromiseBatch
 
 T = TypeVar("T")

--- a/src/near_sdk_py/storage.py
+++ b/src/near_sdk_py/storage.py
@@ -6,6 +6,7 @@ import json
 from typing import Any, List, Optional, Union
 
 import near
+
 from .contract import StorageError
 
 

--- a/tests/collections/conftest.py
+++ b/tests/collections/conftest.py
@@ -7,7 +7,6 @@ from typing import Dict, Optional
 
 import pytest
 
-
 # Mock storage - this will simulate the blockchain storage
 mock_storage: Dict[str, bytes] = {}
 

--- a/tests/collections/storage_benchmark.py
+++ b/tests/collections/storage_benchmark.py
@@ -5,16 +5,18 @@ This script measures storage units used by different collection operations,
 which directly corresponds to gas costs in NEAR smart contracts.
 """
 
+from typing import Dict, Tuple
+
 from rich.console import Console
 from rich.table import Table
-from typing import Dict, Tuple
+
+from near_sdk_py.collections.lookup_map import LookupMap
+from near_sdk_py.collections.lookup_set import LookupSet
+from near_sdk_py.collections.tree_map import TreeMap
+from near_sdk_py.collections.unordered_map import UnorderedMap
 
 # Import collections
 from near_sdk_py.collections.vector import Vector
-from near_sdk_py.collections.lookup_map import LookupMap
-from near_sdk_py.collections.lookup_set import LookupSet
-from near_sdk_py.collections.unordered_map import UnorderedMap
-from near_sdk_py.collections.tree_map import TreeMap
 
 
 def calculate_storage_size(storage_dict: Dict[str, bytes]) -> int:

--- a/tests/collections/test_bytes_handling.py
+++ b/tests/collections/test_bytes_handling.py
@@ -2,9 +2,9 @@
 Tests for handling bytes objects in the collections.
 """
 
-from near_sdk_py.collections.vector import Vector
 from near_sdk_py.collections.lookup_map import LookupMap
 from near_sdk_py.collections.unordered_map import UnorderedMap
+from near_sdk_py.collections.vector import Vector
 
 
 def test_bytes_in_vector(setup_storage_mocks, dump_storage):

--- a/tests/collections/test_lookup_set.py
+++ b/tests/collections/test_lookup_set.py
@@ -4,9 +4,10 @@ Unit tests for LookupSet collection.
 
 import pytest
 
+from near_sdk_py.collections.adapter import CollectionStorageAdapter
+
 # Import the collection we want to test
 from near_sdk_py.collections.lookup_set import LookupSet
-from near_sdk_py.collections.adapter import CollectionStorageAdapter
 
 
 def test_lookup_set_basics(setup_storage_mocks):


### PR DESCRIPTION
Adds `isort` functionality to `ruff` with `extend-select = ["I"]` and formats all the files