### PR TITLE
feat: Add efficient pagination support to UnorderedMap and UnorderedSet

### DIFF
--- a/src/near_sdk_py/collections/unordered_map.py
+++ b/src/near_sdk_py/collections/unordered_map.py
@@ -2,7 +2,7 @@
 UnorderedMap collection for NEAR smart contracts.
 """
 
-from typing import Any, Iterator, Tuple  # Keep typing for docs
+from typing import Any, Iterator, Optional, Tuple  # Keep typing for docs
 
 import near
 
@@ -93,10 +93,46 @@ class UnorderedMap(LookupMap):
         for key in self._keys_vector:
             yield self[key]
 
-    def items(self) -> Iterator[Tuple[Any, Any]]:
-        """Return an iterator over the (key, value) pairs"""
-        for key in self._keys_vector:
+    def items(
+        self, start_index: int = 0, limit: Optional[int] = None
+    ) -> Iterator[Tuple[Any, Any]]:
+        """
+        Return an iterator over the (key, value) pairs with pagination support.
+
+        Args:
+            start_index: Index to start iterating from (0-based)
+            limit: Maximum number of items to return
+
+        Returns:
+            Iterator over (key, value) pairs
+        """
+        keys_count = len(self._keys_vector)
+
+        if start_index >= keys_count:
+            return
+
+        end_index = (
+            keys_count if limit is None else min(start_index + limit, keys_count)
+        )
+
+        for i in range(start_index, end_index):
+            key = self._keys_vector[i]
             yield (key, self[key])
+
+    def seek(
+        self, start_index: int = 0, limit: Optional[int] = None
+    ) -> Iterator[Tuple[Any, Any]]:
+        """
+        Efficiently seek to a specific position and return items.
+
+        Args:
+            start_index: Index to start from (0-based)
+            limit: Maximum number of items to return
+
+        Returns:
+            Iterator over (key, value) pairs
+        """
+        return self.items(start_index, limit)
 
     def clear(self) -> None:
         """Remove all elements from the map"""

--- a/src/near_sdk_py/collections/unordered_set.py
+++ b/src/near_sdk_py/collections/unordered_set.py
@@ -2,7 +2,7 @@
 UnorderedSet collection for NEAR smart contracts.
 """
 
-from typing import Any, Iterator  # Keep typing for docs
+from typing import Any, Iterator, Optional  # Keep typing for docs
 
 import near
 
@@ -80,11 +80,45 @@ class UnorderedSet(LookupSet):
 
     def __iter__(self) -> Iterator:
         """Return an iterator over the values"""
-        return iter(self._values_vector)
+        return iter(self.values())
 
-    def values(self) -> Iterator[Any]:
-        """Return an iterator over the values"""
-        return iter(self._values_vector)
+    def values(
+        self, start_index: int = 0, limit: Optional[int] = None
+    ) -> Iterator[Any]:
+        """
+        Return an iterator over the values with pagination support.
+
+        Args:
+            start_index: Index to start iterating from (0-based)
+            limit: Maximum number of values to return
+
+        Returns:
+            Iterator over values
+        """
+        values_count = len(self._values_vector)
+
+        if start_index >= values_count:
+            return
+
+        end_index = (
+            values_count if limit is None else min(start_index + limit, values_count)
+        )
+
+        for i in range(start_index, end_index):
+            yield self._values_vector[i]
+
+    def seek(self, start_index: int = 0, limit: Optional[int] = None) -> Iterator[Any]:
+        """
+        Efficiently seek to a specific position and return values.
+
+        Args:
+            start_index: Index to start from (0-based)
+            limit: Maximum number of values to return
+
+        Returns:
+            Iterator over values
+        """
+        return self.values(start_index, limit)
 
     def clear(self) -> None:
         """Remove all values from the set"""


### PR DESCRIPTION
This PR adds pagination capabilities to collection types to enable gas-efficient iteration patterns.

## Changes

- Added `seek` method to `UnorderedMap` that allows starting iteration from a specific index with an optional limit
- Enhanced `items()` in `UnorderedMap` to support pagination parameters
- Added similar pagination support to `UnorderedSet` with `seek` and updated `values()` methods
- Updated type hints to properly handle optional parameters using `Optional[int]`

## Motivation

Without efficient pagination, these collections offered limited advantages over their non-iterable counterparts (`LookupMap` and `LookupSet`). This change ensures the "Iterable" aspect of these collections is truly gas-efficient for real-world use cases.